### PR TITLE
merge branch 'CPPST-5--Fix-warnings-on-linux' into 'main'

### DIFF
--- a/Projects/CustomLinkedList/customLinkedList.cpp
+++ b/Projects/CustomLinkedList/customLinkedList.cpp
@@ -156,10 +156,11 @@ namespace NaM
 struct Point2D
 {
     std::int32_t x{0}, y{ 0 };
-    [[nodiscard]] inline const std::string& ToString() const
+    [[nodiscard]] inline const std::string ToString() const
     {
         std::stringstream ss;
         ss << "*pNode (" << this << ") = *this";
+        return ss.str();
     }
 };
 


### PR DESCRIPTION
Test build of main on linux returned
```
$ make all
Consolidate compiler generated dependencies of target CustomLinkedList
[ 25%] Building CXX object Projects/CustomLinkedList/CMakeFiles/CustomLinkedList.dir/customLinkedList.cpp.o
/Projects/CustomLinkedList/customLinkedList.cpp: In member function ‘const string& Point2D::ToString() const’:
/Projects/CustomLinkedList/customLinkedList.cpp:163:5: warning: no return statement in function returning non-void [-Wreturn-type]
  163 |     }
      |     ^
[ 50%] Linking CXX executable CustomLinkedList
[ 50%] Built target CustomLinkedList
```

Properly return the string.
Return a string object, not a reference to a temporary string
